### PR TITLE
Add version subscription notifications and background version polling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discord_search_bot"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 publish = false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,18 +9,8 @@ services:
     environment:
       - DISCORD_TOKEN=$DISCORD_TOKEN
       - DATABASE_URL=sqlite:///app/data/discord_bot.db?mode=rwc
+      - VERSION_CHECK_INTERVAL_SECS=86400
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-    restart: unless-stopped
-    labels:
-      - "com.centurylinklabs.watchtower.scope=discord-search-bot-scope"
-
-  watchtower:
-    image: containrrr/watchtower
-    profiles:
-      - auto-update
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: --scope discord-search-bot-scope --interval 300 --cleanup
     restart: unless-stopped

--- a/migrations/20260503000000_version_subscriptions.sql
+++ b/migrations/20260503000000_version_subscriptions.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS version_subscriptions (
+    user_id INTEGER PRIMARY KEY,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    last_notified_version TEXT
+);

--- a/readme.md
+++ b/readme.md
@@ -25,19 +25,9 @@ https://discord.com/oauth2/authorize?client_id=1032354931673407620&permissions=1
         environment:
           - DISCORD_TOKEN=여기에_토큰_입력
           - DATABASE_URL=sqlite:///app/data/discord_bot.db?mode=rwc
+          - VERSION_CHECK_INTERVAL_SECS=86400
         volumes:
           - ./data:/app/data
-        restart: unless-stopped
-        labels:
-          - "com.centurylinklabs.watchtower.scope=discord-search-bot-scope"
-    
-      watchtower:
-        image: containrrr/watchtower
-        profiles:
-          - auto-update
-        volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
-        command: --scope discord-search-bot-scope --interval 300 --cleanup
         restart: unless-stopped
     ```
 
@@ -47,10 +37,7 @@ https://discord.com/oauth2/authorize?client_id=1032354931673407620&permissions=1
     ```shell
     docker compose up -d
     ```
-*   자동 업데이트 활성화: 5분마다 최신 버전을 확인하고 자동으로 업데이트합니다.
-    ```shell
-    docker compose --profile auto-update up -d
-    ```
+`VERSION_CHECK_INTERVAL_SECS`는 새 버전 확인 주기(초)입니다.
 
 ### Docker (직접 빌드)
 소스를 수정했거나 직접 빌드하고 싶은 경우
@@ -97,6 +84,12 @@ $ discord_search_bot <YourToken>
 /version
 ```
 현재 봇의 버전 정보와 최신 여부를 확인합니다.
+
+## notify_version
+```
+/notify_version enable:true or false
+```
+새 버전이 감지되면 DM으로 알림을 받습니다.
 
 ## config
 ### caching

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,6 +2,7 @@ mod search;
 mod help;
 mod config;
 mod version;
+mod notify;
 
 use crate::{Data, Error};
 
@@ -11,5 +12,10 @@ pub fn commands() -> Vec<poise::Command<Data, Error>> {
         help::help(),
         config::config(),
         version::version(),
+        notify::notify_version(),
     ]
+}
+
+pub async fn check_latest_version() -> Result<Option<String>, Error> {
+    version::check_latest_version().await
 }

--- a/src/command/notify.rs
+++ b/src/command/notify.rs
@@ -1,0 +1,21 @@
+use crate::{Context, Error};
+use poise::CreateReply;
+
+/// 새 버전 DM 알림을 설정합니다.
+#[poise::command(slash_command)]
+pub(super) async fn notify_version(
+    ctx: Context<'_>,
+    #[description = "Enable or disable update notification DM"] enable: bool,
+) -> Result<(), Error> {
+    let pool = &ctx.data().database;
+    crate::database::set_version_subscription(pool, ctx.author().id.get(), enable).await?;
+
+    let message = if enable {
+        "새 버전 감지 시 DM 알림을 활성화했습니다."
+    } else {
+        "새 버전 DM 알림을 비활성화했습니다."
+    };
+    ctx.send(CreateReply::default().ephemeral(true).content(message))
+        .await?;
+    Ok(())
+}

--- a/src/command/version.rs
+++ b/src/command/version.rs
@@ -44,7 +44,7 @@ pub(super) async fn version(ctx: Context<'_>) -> Result<(), Error> {
     Ok(())
 }
 
-async fn check_latest_version() -> Result<Option<String>, Error> {
+pub(crate) async fn check_latest_version() -> Result<Option<String>, Error> {
     let client = reqwest::Client::new();
 
     // 1. 인증 토큰 획득 (Public 이미지라도 토큰 필요)

--- a/src/database.rs
+++ b/src/database.rs
@@ -196,6 +196,62 @@ pub async fn is_channel_caching_enabled(
     }
 }
 
+pub async fn set_version_subscription(
+    pool: &SqlitePool,
+    user_id: u64,
+    enabled: bool,
+) -> Result<(), sqlx::Error> {
+    let enabled_value = if enabled { 1 } else { 0 };
+    sqlx::query(
+        "INSERT INTO version_subscriptions (user_id, enabled) VALUES (?, ?)
+         ON CONFLICT(user_id) DO UPDATE SET enabled = excluded.enabled",
+    )
+    .bind(user_id as i64)
+    .bind(enabled_value)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub async fn list_version_subscribers(pool: &SqlitePool) -> Result<Vec<i64>, sqlx::Error> {
+    let rows = sqlx::query("SELECT user_id FROM version_subscriptions WHERE enabled = 1")
+        .fetch_all(pool)
+        .await?;
+    rows.into_iter().map(|row| row.try_get("user_id")).collect()
+}
+
+pub async fn mark_version_notified(
+    pool: &SqlitePool,
+    user_id: u64,
+    latest_version: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE version_subscriptions SET last_notified_version = ? WHERE user_id = ?")
+        .bind(latest_version)
+        .bind(user_id as i64)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn should_notify_version(
+    pool: &SqlitePool,
+    user_id: u64,
+    latest_version: &str,
+) -> Result<bool, sqlx::Error> {
+    let row = sqlx::query("SELECT last_notified_version FROM version_subscriptions WHERE user_id = ? AND enabled = 1")
+        .bind(user_id as i64)
+        .fetch_optional(pool)
+        .await?;
+
+    match row {
+        Some(r) => {
+            let last: Option<String> = r.try_get("last_notified_version")?;
+            Ok(last.as_deref() != Some(latest_version))
+        }
+        None => Ok(false),
+    }
+}
+
 pub async fn insert_message(pool: &SqlitePool, msg: &serenity::Message) -> Result<(), sqlx::Error> {
     let guild_id = match msg.guild_id {
         Some(id) => id.get() as i64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod event;
 use dashmap::DashMap;
 use poise::serenity_prelude::ChannelId;
 use sqlx::SqlitePool;
+use std::time::Duration;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 pub struct Data {
@@ -73,6 +74,60 @@ async fn main() {
                     tracing::info!("Production mode: Registering commands globally");
                     poise::builtins::register_globally(ctx, &framework.options().commands).await?;
                 }
+                let pool = database.clone();
+                let http = ctx.http.clone();
+                tokio::spawn(async move {
+                    let interval_secs = std::env::var("VERSION_CHECK_INTERVAL_SECS")
+                        .ok()
+                        .and_then(|v| v.parse::<u64>().ok())
+                        .unwrap_or(86_400);
+                    let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
+                    loop {
+                        ticker.tick().await;
+                        let latest = match crate::command::check_latest_version().await {
+                            Ok(Some(v)) => v,
+                            Ok(None) => continue,
+                            Err(e) => {
+                                tracing::warn!("version polling failed: {}", e);
+                                continue;
+                            }
+                        };
+                        let subscribers = match crate::database::list_version_subscribers(&pool).await {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::warn!("list subscribers failed: {}", e);
+                                continue;
+                            }
+                        };
+                        for user_id in subscribers {
+                            let uid = user_id as u64;
+                            let should_notify = match crate::database::should_notify_version(&pool, uid, &latest).await {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    tracing::warn!("should_notify_version failed for {}: {}", uid, e);
+                                    false
+                                }
+                            };
+                            if !should_notify {
+                                continue;
+                            }
+                            let user = match poise::serenity_prelude::UserId::new(uid).to_user(&http).await {
+                                Ok(u) => u,
+                                Err(_) => continue,
+                            };
+                            let dm = user.dm(
+                                &http,
+                                poise::serenity_prelude::CreateMessage::new().content(format!(
+                                    "새 버전 `{}` 이 감지되었습니다. `/version`으로 확인해보세요.",
+                                    latest
+                                )),
+                            ).await;
+                            if dm.is_ok() {
+                                let _ = crate::database::mark_version_notified(&pool, uid, &latest).await;
+                            }
+                        }
+                    }
+                });
                 Ok(Data {
                     database,
                     live_ranges: DashMap::new(),


### PR DESCRIPTION
### Motivation
- Provide users an opt-in way to receive DM notifications when a new bot version is published and enable periodic automated version checks.
- Persist user subscription preferences and avoid repeat notifications by recording the last-notified version in the database.

### Description
- Added a new `version_subscriptions` migration SQL to track `user_id`, `enabled`, and `last_notified_version`.
- Implemented subscription management DB functions: `set_version_subscription`, `list_version_subscribers`, `mark_version_notified`, and `should_notify_version` in `src/database.rs`.
- Added a new slash command `notify_version` in `src/command/notify.rs` and registered it in the commands list to let users `enable`/`disable` DM update notifications.
- Exposed the existing version-check helper as `pub(crate) check_latest_version` and added `command::check_latest_version` wrapper for reuse.
- Spawned a background task in `main` that periodically polls the GHCR tags (interval configurable via `VERSION_CHECK_INTERVAL_SECS`, default `86400` seconds) and DMs subscribed users about new versions, updating `last_notified_version` after successful DM.
- Updated `Cargo.toml` version to `0.7.7`, added `VERSION_CHECK_INTERVAL_SECS` environment variable in `docker-compose.yml`, and updated `readme.md` with `notify_version` docs and the new env var; removed the watchtower service and related docs/labels.

### Testing
- Built the project with `cargo build --release` and the build completed successfully.
- Applied the new migration and validated the `version_subscriptions` table exists via `sqlx` migration tooling (migration run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f755f113c4832990746e23a66ada18)